### PR TITLE
2.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Magnetic Nanoparticle Assembly Utilities (MAGNA-U)
-#### Version 2.3.2
+#### Version 2.3.3
 
 | Description| Badge|
 | --------|-------|
@@ -387,7 +387,7 @@ colored by either the z component (default) or the xy angle component by using
 will likely take significantly longer than coloring using z.
    
 ### Changelog
-- Version 2.3.2 (8 Jun 2021)
+- Version 2.3.2 and 2.3.3 (8 Jun 2021)
     - fixed `MNP_Analyzer.extract()` to allow it to extract angle values for centers
         not in the `z = 0` plane
 - Version 2.3.1 (27 May 2021)

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ version using the `load_mnp()` function.
 |[`quick_drive`](Quick_Drive.md)| Easy way to drive an MNP assembly|
 
 ## Changelog
-- Version 2.3.2 (8 Jun 2021)
+- Version 2.3.2 and 2.3.3 (8 Jun 2021)
     - fixed `MNP_Analyzer.extract()` to allow it to extract angle values for centers
         not in the `z = 0` plane
 - Version 2.3.1 (27 May 2021)

--- a/magna/utils.py
+++ b/magna/utils.py
@@ -737,10 +737,10 @@ class MNP_Analyzer:
         mz = []
         angle = []
         for point in self.mnp.scaled_coords:
+            x, y, z = point
             mx.append(self.field.orientation.line(p1 = (point), p2 = (0, 0, 0), n = 2).data.vx[0]),
             my.append(self.field.orientation.line(p1 = (point), p2 = (0, 0, 0), n = 2).data.vy[0]),
-            z = (self.field.orientation.line(p1 = (point), p2 = (0, 0, 0), n = 2).data.vz[0])
-            mz.append(z)
+            mz.append(self.field.orientation.line(p1 = (point), p2 = (0, 0, 0), n = 2).data.vz[0])
             angle.append(self.field.plane(z = z).angle.line(p1 = point, p2 = (0, 0, z), n = 2).data.v[0])
         table = np.column_stack((x, y, z, mx, my, mz, angle))
         table.tofile(os.path.join(self.mnp.filepath, 'centers_data.csv'), sep = ',')

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='magna',
-      version='2.3.2',
+      version='2.3.3',
       description='magnetic nanoparticle assembly utilities',
       url='https://github.com/sammysiegel/MAGNA-U',
       authors=['Sammy Siegel', 'Niels Vanderloo', 'Yumi Ijiri'],


### PR DESCRIPTION
- HOTFIX fixed `MNP_Analyzer.extract()` to allow it to extract angle values for centers not in the z = 0 plane