### PR TITLE
- Version 2.4.0 (11 June 2021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Magnetic Nanoparticle Assembly Utilities (MAGNA-U)
-#### Version 2.3.3
+#### Version 2.4.0
 
 | Description| Badge|
 | --------|-------|
@@ -387,6 +387,9 @@ colored by either the z component (default) or the xy angle component by using
 will likely take significantly longer than coloring using z.
    
 ### Changelog
+- Version 2.4.0 (11 June 2021)
+    - `k3d_center_vectors()`: addition of coloring by layer with `color_field = 'layer'`, 
+      scaling with `scale`, and color mapping with `cmap`.
 - Version 2.3.4 (9 Jun 2021)
     - fixed `MNP_Analyzer.extract()` to allow it to extract angle values for centers
         not in the `z = 0` plane

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,10 @@ version using the `load_mnp()` function.
 |[`quick_drive`](Quick_Drive.md)| Easy way to drive an MNP assembly|
 
 ## Changelog
-- Version 2.3.4 (9 Jun 2021)
+- Version 2.4.0 (11 June 2021)
+    - `k3d_center_vectors()`: addition of coloring by layer with `color_field = 'layer'`, 
+      scaling with `scale`, and color mapping with `cmap`.
+- Version 2.3.4 (9 June 2021)
     - fixed `MNP_Analyzer.extract()` to allow it to extract angle values for centers
         not in the `z = 0` plane
 - Version 2.3.1 (27 May 2021)

--- a/magna/utils.py
+++ b/magna/utils.py
@@ -797,9 +797,10 @@ class MNP_Analyzer:
         data = np.genfromtxt(os.path.join(self.mnp.filepath, 'centers_data.csv'), delimiter = ',')
         data = data.reshape(-1, 7)
         center_magnetization = np.column_stack((data[:, 3], data[:, 4], data[:, 5]))
-        data[:, 0] = scale[0] * data[:, 0]
-        data[:, 1] = scale[1] * data[:, 1]
-        data[:, 2] = scale[2] * data[:, 2]
+        origins = self.mnp.coord_list.astype(np.float32)
+        origins[:, 0] *= scale[0]
+        origins[:, 1] *= scale[1]
+        origins[:, 2] *= scale[2]
 
         if color_field == 'z':
             if cmap is None:
@@ -814,7 +815,7 @@ class MNP_Analyzer:
         elif color_field == 'layer':
             print("Getting Layer...")
             if cmap is None:
-                cmap = 'hot'
+                cmap = 'rainbow'
             color_values = data[:, 2]
         else:
             raise AttributeError("color_field should be 'z', 'angle', or 'layer'.")
@@ -833,7 +834,7 @@ class MNP_Analyzer:
 
         plot = k3d.plot()
         plot.display()
-        plot += k3d.vectors(origins = self.mnp.coord_list.astype(np.float32),
+        plot += k3d.vectors(origins = origins,
                             vectors = center_magnetization.astype(np.float32), model_matrix = model_matrix,
                             colors = colors,
                             line_width = .02, head_size = 2, use_head = True)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='magna',
-      version='2.4.0-a',
+      version='2.4.0',
       description='magnetic nanoparticle assembly utilities',
       url='https://github.com/sammysiegel/MAGNA-U',
       authors=['Sammy Siegel', 'Niels Vanderloo', 'Yumi Ijiri'],


### PR DESCRIPTION
    - `k3d_center_vectors()`: addition of coloring by layer with `color_field = 'layer'`,
      scaling with `scale`, and color mapping with `cmap`.