### PR TITLE
- Version 2.5.0-beta-0 (22 July 2021)

### DIFF
--- a/install.py
+++ b/install.py
@@ -33,3 +33,12 @@ except ModuleNotFoundError:
     if answer == 'y':
         os.system('pip install opencv-python')
 
+try:
+    import networkx
+except ModuleNotFoundError:
+    print('\033[0;33;40mWARNING: MAGNA-U has detected that the python module NetworkX is not installed. This is needed'
+          ' in order to find the domains of MNP assemblies.')
+    answer = input('Would you like to install NetworkX now? [y/n]\033[0;0m')
+    if answer == 'y':
+        os.system('pip install networkx')
+

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='magna',
-      version='2.5.0-alpha-1',
+      version='2.5.0-beta-0',
       description='magnetic nanoparticle assembly utilities',
       url='https://github.com/sammysiegel/MAGNA-U',
       authors=['Sammy Siegel', 'Niels Vanderloo', 'Yumi Ijiri'],


### PR DESCRIPTION
    - reverted back to original distance finding method from cdist
    - added MNP_Domain_Analyzer
    - added choice of easy axes with axes_type:'random_hexagonal', 'random_plane', 'all_random'
    - now using networks to find domain regions