### PR TITLE
- Version 2.5.0-beta-1 (22 July 2021)

### DIFF
--- a/magna/utils.py
+++ b/magna/utils.py
@@ -1163,6 +1163,10 @@ class MNP_Domain_Analyzer(MNP_Analyzer):
         return (n/len(self.mnp.coord_list))
 
     @property
+    def free_particle_fraction(self):
+        return self.region_list.count(1)/len(self.mnp.coord_list)
+
+    @property
     def domains_summary(self):
         csize = self.characteristic_size
 
@@ -1175,15 +1179,17 @@ class MNP_Domain_Analyzer(MNP_Analyzer):
                  '| Characteristic Domain Size             | {:<10} |\n'
                  '| Max Domain Size                        | {:<10} |\n'
                  '| Average Domain Size                    | {:<10} |\n'
+                 '| Free Particle Fraction                 | {:<10} |\n'
                  '\n'
                  'Domain Size List: {}').format(self.mnp.id, self.mnp.id, len(self.mnp.coord_list),
                                               len(self.region_list), csize,
-                                              max(self.region_list), np.mean(self.region_list), self.region_list))
+                                              max(self.region_list), np.mean(self.region_list),
+                                              self. free_particle_fraction,self.region_list))
 
     def save_domains(self):
         data_list = [self.mnp.id, len(self.mnp.coord_list),
                      len(self.region_list), self.characteristic_size,
-                     max(self.region_list), np.mean(self.region_list), self.region_list]
+                     max(self.region_list), np.mean(self.region_list), self.region_list, self.free_particle_fraction]
         with open(os.path.join(self.mnp.filepath, 'domain_data_mnp_{}.csv'.format(self.mnp.id)), 'w') as f:
             write = csv.writer(f)
             write.writerow(data_list)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='magna',
-      version='2.5.0-beta-0',
+      version='2.5.0-beta-1',
       description='magnetic nanoparticle assembly utilities',
       url='https://github.com/sammysiegel/MAGNA-U',
       authors=['Sammy Siegel', 'Niels Vanderloo', 'Yumi Ijiri'],


### PR DESCRIPTION
    - reverted back to original distance finding method from cdist
    - added MNP_Domain_Analyzer
         - now using networks to find domain regions
         - metrics: characteristic size, max size, mean size, free particle fraction
         - region plots: as spheres or vectors
         - saving domain region data/getting summary data
    - added choice of easy axes with axes_type:'random_hexagonal', 'random_plane', 'all_random'